### PR TITLE
fix: Bearer token authentication, query preparation, variable naming

### DIFF
--- a/githubgql/Client.py
+++ b/githubgql/Client.py
@@ -243,24 +243,24 @@ class GitHubGQL:
 
         Example::
 
-            results = client.execute_all(query, vars, 5)
+            results = client.execute_all(query, variables, 5)
         """
         paginator = Paginator(
-            self.gql_client, query, vars, page_size=self.default_page_size, auto_fit_quotas=self.auto_fit_quotas
+            self.gql_client, query, variables, page_size=self.default_page_size, auto_fit_quotas=self.auto_fit_quotas
         )
         merged_results = {}
         for result in paginator:
             GitHubGQL.Merger.merge(merged_results, result)
         return merged_results
 
-    def execute_iter(self, query: str, *, vars: dict[str, str] = None) -> Iterator:
+    def execute_iter(self, query: str, *, variables: dict[str, str] = None) -> Iterator:
         """Return an iterator for the provided query.
 
         Args:
             query: The query to execute. This can be standard GraphQL as
                 described by online documentation, or a simplified, GitHub-only
                 version with auto-pagination as described above.
-            vars: The variables to substitute into the query.
+            variables: The variables to substitute into the query.
 
         Returns:
             An iterator allowing the client to control their own merging
@@ -275,9 +275,9 @@ class GitHubGQL:
                     # Got what we need
                     break
         """
-        return Paginator(self.gql_client, query, vars, self.default_page_size).__iter__()
+        return Paginator(self.gql_client, query, variables, self.default_page_size).__iter__()
 
-    def execute_callback(self, callback: GitHubGQL.Callback, query: str, *, vars: dict[str, str] = None) -> None:
+    def execute_callback(self, callback: GitHubGQL.Callback, query: str, *, variables: dict[str, str] = None) -> None:
         """Execute the query page by page, calling `callback` for each page.
 
         Args:
@@ -288,7 +288,7 @@ class GitHubGQL:
             query: The query to execute. This can be standard GraphQL as
                 described by online documentation, or a simplified, GitHub-only
                 version with auto-pagination as described above.
-            vars: The variables to substitute into the query.
+            variables: The variables to substitute into the query.
 
         Returns:
             Nothing
@@ -306,7 +306,7 @@ class GitHubGQL:
 
             client.execute_callback(callback)
         """
-        paginator = Paginator(self.gql_client, query, vars, self.default_page_size)
+        paginator = Paginator(self.gql_client, query, variables, self.default_page_size)
         try:
             for result in paginator:
                 if not callback(result):

--- a/githubgql/Client.py
+++ b/githubgql/Client.py
@@ -145,6 +145,16 @@ from .Merger import Merger
 from .Paginator import Paginator
 from .Schema import Schema
 
+from requests.auth import AuthBase
+
+
+class BearerTokenAuth(AuthBase):
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, request):
+        request.headers['Authorization'] = f"Bearer {self.token}"
+        return request
 
 class GitHubGQL:
 
@@ -213,18 +223,18 @@ class GitHubGQL:
             self.inject_default_fields = inject_default_fields
             self.cleanup_query = cleanup_query
             gql_transport = RequestsHTTPTransport(
-                url=Config.get().github_graphql_endpoint, headers={"Authorization": f"bearer {pat}"}
+                url=Config.get().github_graphql_endpoint, auth=BearerTokenAuth(pat)
             )
             self.gql_client = GQLClient(schema=Schema.get(), transport=gql_transport)
 
-    def execute_all(self, query: str, *, vars: dict[str, str] = None) -> ResultPage:
+    def execute_all(self, query: str, *, variables: dict[str, str] = None) -> ResultPage:
         """Execute the provided query to completion, with as many calls as necessary.
 
         Args:
             query: The query to execute. This can be standard GraphQL as
                 described by online documentation, or a simplified, GitHub-only
                 version with auto-pagination as described above.
-            vars: The variables to substitute into the query.
+            variables: The variables to substitute into the query.
 
         Returns:
             A dictionary containing the results of the query executed. If a

--- a/githubgql/Clock.py
+++ b/githubgql/Clock.py
@@ -36,4 +36,4 @@ class Clock:
 
     def __exit__(self, exc_type, exc_value, traceback):
         if Config.get().clock_on:
-            print(f"done ({(time() - self.enter_time):.3f}s)", sys.stderr)
+            print(f"done ({(time() - self.enter_time):.3f}s)", file=sys.stderr)

--- a/githubgql/Paginator.py
+++ b/githubgql/Paginator.py
@@ -16,7 +16,7 @@ class Paginator:
         self,
         gql_client: GQLClient,
         query_str: str,
-        vars: dict[str, str],
+        variables: dict[str, str],
         *,
         page_size=100,
         auto_fit_quotas=True,
@@ -31,7 +31,7 @@ class Paginator:
             inject_default_fields=inject_default_fields,
             cleanup_query=cleanup_query,
         )
-        self.vars = vars
+        self.variables = variables
         self.complete = False
 
     def __iter__(self) -> Paginator:

--- a/githubgql/Paginator.py
+++ b/githubgql/Paginator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from gql import Client as GQLClient
+from gql import gql
 
 from .Clock import Clock
 from .PathKey import PathKey
@@ -41,7 +42,9 @@ class Paginator:
             raise StopIteration
         else:
             with Clock("Sending query to GitHub GraphQL API"):
-                results = self.gql_client.execute(self.query.get_doc(), self.vars)
+                the_query = gql(self.query.get_doc())
+                the_query.variable_values = self.variables
+                results = self.gql_client.execute(the_query)
             self.complete = not self._update_pagination(Results(results))
             return results
 


### PR DESCRIPTION
I don't see a contribution policy for this repository, but it looked promising for a problem that I wanted to solve.  So I adapted it for my use case.

My environment is macOS Sequoia 15.6.1 on a MacBook Pro (November 2023), Apple M3 silicon; Python obtained via [Homebrew](https://brew.sh).

```
$ uname -a
Darwin OPLN-L-7P6VP6HQ 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:28:30 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T6030 arm64

$ python3 -V
Python 3.13.7

$ pip freeze
aiohappyeyeballs==2.6.1
aiohttp==3.12.15
aiosignal==1.4.0
anyio==4.10.0
attrs==25.3.0
backoff==2.2.1
certifi==2025.8.3
charset-normalizer==3.4.3
deepmerge==2.0
dill==0.4.0
frozenlist==1.7.0
github-graphql-paginator==0.0.3
gql==4.0.0
graphql-core==3.2.6
idna==3.10
multidict==6.6.4
propcache==0.3.2
PyYAML==6.0.2
requests==2.32.5
requests-toolbelt==1.0.0
sniffio==1.3.1
urllib3==2.5.0
yarl==1.20.1

$ cat requirements.txt
requests
github-graphql-paginator
```

 Specifically, I was looking for repositories in one of my employer's organizations that contained key files indicating certain languages or continuous integration systems, so I could estimate the impact and level of effort if we were to change vendors for continuous integration and artifact storage.  The pagination and query rewrite features appear to work very well, and they genuinely saved me from writing a bunch of boring code to retrieve page after page of what I knew would be a long query.  Once I got past the hurdles described in the pull request title, I scanned over 1500 repositories with the GraphQL API, and the results aggregated flawlessly.

Thank you for writing this library.  I didn't think I'd write a pull request as a gesture of gratitude, but it seemed appropriate.